### PR TITLE
✨Add Boolean and File I/O notebooks with sample files

### DIFF
--- a/files/temp.txt
+++ b/files/temp.txt
@@ -1,0 +1,7 @@
+The quick brown fox jumps over the lazy dog.
+Machine learning algorithms process large datasets efficiently.
+Cloud computing enables scalable infrastructure solutions.
+Python is a versatile language for data science.
+Recursive functions solve complex problems elegantly.
+Natural language processing transforms text into insights.
+Version control systems track code changes systematically.

--- a/files/temp_new.txt
+++ b/files/temp_new.txt
@@ -1,0 +1,1 @@
+This is a new line added to the new file.

--- a/files/test.txt
+++ b/files/test.txt
@@ -1,1 +1,3 @@
-This is a new file created by the %%writefile magic command in Jupyter Notebook.
+This is a new line added to the file.
+This is another line added to the file.
+This line is added to the end of the file using append mode.

--- a/files/test.txt
+++ b/files/test.txt
@@ -1,0 +1,1 @@
+This is a new file created by the %%writefile magic command in Jupyter Notebook.

--- a/notebooks/python-booleans.ipynb
+++ b/notebooks/python-booleans.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b9f391ad",
+   "metadata": {},
+   "source": [
+    "# Understanding Booleans in Python\n",
+    "\n",
+    "This notebook is dedicated to exploring Boolean values in Python. It will cover:\n",
+    "\n",
+    "- The two Boolean constants: `True` and `False`\n",
+    "- Boolean expressions and comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`)\n",
+    "- Logical operators (`and`, `or`, `not`)\n",
+    "- Truthiness and falsiness of different data types\n",
+    "- Practical examples using Booleans in conditional statements and loops"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "74f55f48",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2def9fbc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ec706f85",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bool"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3f0618fb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1==1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "39123e63",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1==2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6b59ee63",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1 or 0"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/python-files.ipynb
+++ b/notebooks/python-files.ipynb
@@ -184,6 +184,38 @@
     "myfile.seek(0)\n",
     "myfile.readlines() # Read the file again, this time it will return a list of lines in the file since we used readlines() instead of read()."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "250966d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "myfile.close() \n",
+    "# Always remember to close the file after you're done with it to free up system resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b0af3e55",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is a new file created by the %%writefile magic command in Jupyter Notebook.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(\"../files/test.txt\", \"r\") as myfile:\n",
+    "    content = myfile.read()\n",
+    "    print(content)"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/python-files.ipynb
+++ b/notebooks/python-files.ipynb
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "1d59b0a8",
    "metadata": {},
    "outputs": [
@@ -266,11 +266,50 @@
     "with open(\"../files/test.txt\", mode=\"w\") as myfile:\n",
     "        myfile.write(\"This is a new line added to the file.\\n\")\n",
     "        myfile.write(\"This is another line added to the file.\\n\")\n",
+    "# The 'w' mode will overwrite the existing content of the file, so only the new lines will be present in the file after this block.\n",
     "with open(\"../files/test.txt\", \"a+\") as mynewfile:\n",
     "    mynewfile.write(\"This line is added to the end of the file using append mode.\\n\")\n",
-    "    mynewfile.seek(0) # Move the file pointer back to the beginning of the file to read the content after appending.\n",
+    "    mynewfile.seek(0) \n",
+    "# Move the file pointer back to the beginning of the file to read the content after appending.\n",
     "    content = mynewfile.read()\n",
     "    print(content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "082103de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"../files/temp_new.txt\", \"a\") as myfile:\n",
+    "    myfile.write(\"This is a new line added to the new file.\\n\")\n",
+    "# This will create a new file named temp_new.txt and add the line to it. If the file already exists, it will append the line to the existing content.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "5036b0a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileExistsError",
+     "evalue": "[Errno 17] File exists: '../files/temp.txt'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mFileExistsError\u001b[0m                           Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[26], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m../files/temp.txt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m myfile:\n\u001b[0;32m      2\u001b[0m     myfile\u001b[38;5;241m.\u001b[39mwrite(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThis is a new line added to the new file.\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m      3\u001b[0m \u001b[38;5;66;03m# The 'x' mode will create a new file and write to it. If the file already exists, it will raise a FileExistsError.\u001b[39;00m\n",
+      "File \u001b[1;32mc:\\Users\\kanwal\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\IPython\\core\\interactiveshell.py:324\u001b[0m, in \u001b[0;36m_modified_open\u001b[1;34m(file, *args, **kwargs)\u001b[0m\n\u001b[0;32m    317\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m file \u001b[38;5;129;01min\u001b[39;00m {\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m}:\n\u001b[0;32m    318\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[0;32m    319\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIPython won\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mt let you open fd=\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfile\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m by default \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    320\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mas it is likely to crash IPython. If you know what you are doing, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    321\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124myou can use builtins\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m open.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    322\u001b[0m     )\n\u001b[1;32m--> 324\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m io_open(file, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+      "\u001b[1;31mFileExistsError\u001b[0m: [Errno 17] File exists: '../files/temp.txt'"
+     ]
+    }
+   ],
+   "source": [
+    "with open(\"../files/temp.txt\", \"x\") as myfile:\n",
+    "    myfile.write(\"This is a new line added to the new file.\\n\")\n",
+    "# The 'x' mode will create a new file and write to it. If the file already exists, it will raise a FileExistsError."
    ]
   }
  ],

--- a/notebooks/python-files.ipynb
+++ b/notebooks/python-files.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d2551b47",
+   "metadata": {},
+   "source": [
+    "# File I/O Experimentation Notebook\n",
+    "\n",
+    "This notebook is dedicated to experimenting with file input/output in Python. It will cover common operations such as:\n",
+    "\n",
+    "- Reading from text and binary files\n",
+    "- Writing data to files\n",
+    "- Working with file paths and directories\n",
+    "- Using context managers (`with` statements) for safe file handling\n",
+    "- Exploring file modes (`r`, `w`, `a`, `rb`, `wb`, etc.)\n",
+    "\n",
+    "Use this notebook to test and document different file I/O patterns and behaviors in Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "15434d9b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing ../files/test.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ../files/test.txt\n",
+    "This is a new file created by the %%writefile magic command in Jupyter Notebook."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/python-files.ipynb
+++ b/notebooks/python-files.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "15434d9b",
    "metadata": {},
    "outputs": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 20,
    "id": "925c6f04",
    "metadata": {},
    "outputs": [],
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 21,
    "id": "674446c4",
    "metadata": {},
    "outputs": [
@@ -60,7 +60,7 @@
      "traceback": [
       "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[10], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m incorrectfile \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m../files/incorrect.txt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mr\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;66;03m# This will raise a FileNotFoundError since the file does not exist.\u001b[39;00m\n",
+      "Cell \u001b[1;32mIn[21], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m incorrectfile \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m../files/incorrect.txt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mr\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;66;03m# This will raise a FileNotFoundError since the file does not exist.\u001b[39;00m\n",
       "File \u001b[1;32mc:\\Users\\kanwal\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\IPython\\core\\interactiveshell.py:324\u001b[0m, in \u001b[0;36m_modified_open\u001b[1;34m(file, *args, **kwargs)\u001b[0m\n\u001b[0;32m    317\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m file \u001b[38;5;129;01min\u001b[39;00m {\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m}:\n\u001b[0;32m    318\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[0;32m    319\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIPython won\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mt let you open fd=\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfile\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m by default \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    320\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mas it is likely to crash IPython. If you know what you are doing, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    321\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124myou can use builtins\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m open.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    322\u001b[0m     )\n\u001b[1;32m--> 324\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m io_open(file, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
       "\u001b[1;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '../files/incorrect.txt'"
      ]
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "97d783ae",
    "metadata": {},
    "outputs": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "542306e4",
    "metadata": {},
    "outputs": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "66397364",
    "metadata": {},
    "outputs": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "b0b25510",
    "metadata": {},
    "outputs": [
@@ -197,6 +197,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b238300e",
+   "metadata": {},
+   "source": [
+    "# Python File Open Modes\n",
+    "\n",
+    "When you open a file in Python using `open(path, mode)`, the `mode` string controls how the file is opened. Common modes include:\n",
+    "\n",
+    "- `r` : read (default). File must exist.\n",
+    "- `w` : write. Creates a new file or truncates an existing file.\n",
+    "- `a` : append. Opens for writing, adding data to the end of the file if it exists.\n",
+    "- `x` : exclusive creation. Fails if the file already exists.\n",
+    "\n",
+    "You can combine these with:\n",
+    "\n",
+    "- `b` : binary mode (e.g., `rb`, `wb`, `ab`). Use for non-text data.\n",
+    "- `t` : text mode (default). Can be explicit (`rt`, `wt`, etc.).\n",
+    "\n",
+    "You can also allow both reading and writing:\n",
+    "\n",
+    "- `r+` : read/write, file must exist (does not truncate).\n",
+    "- `w+` : read/write, truncates the file or creates it.\n",
+    "- `a+` : read/append, creates file if it does not exist; writes go to end unless you seek.\n",
+    "- `x+` : create and open for read/write, fails if file exists.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 17,
    "id": "b0af3e55",
@@ -214,6 +241,35 @@
    "source": [
     "with open(\"../files/test.txt\", \"r\") as myfile:\n",
     "    content = myfile.read()\n",
+    "    print(content)\n",
+    "# The file is automatically closed when exiting the 'with' block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "1d59b0a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is a new line added to the file.\n",
+      "This is another line added to the file.\n",
+      "This line is added to the end of the file using append mode.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(\"../files/test.txt\", mode=\"w\") as myfile:\n",
+    "        myfile.write(\"This is a new line added to the file.\\n\")\n",
+    "        myfile.write(\"This is another line added to the file.\\n\")\n",
+    "with open(\"../files/test.txt\", \"a+\") as mynewfile:\n",
+    "    mynewfile.write(\"This line is added to the end of the file using append mode.\\n\")\n",
+    "    mynewfile.seek(0) # Move the file pointer back to the beginning of the file to read the content after appending.\n",
+    "    content = mynewfile.read()\n",
     "    print(content)"
    ]
   }

--- a/notebooks/python-files.ipynb
+++ b/notebooks/python-files.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "id": "15434d9b",
    "metadata": {},
    "outputs": [
@@ -28,13 +28,161 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing ../files/test.txt\n"
+      "Overwriting ../files/test.txt\n"
      ]
     }
    ],
    "source": [
     "%%writefile ../files/test.txt\n",
     "This is a new file created by the %%writefile magic command in Jupyter Notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "925c6f04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "myfile = open(\"../files/temp.txt\", \"r\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "674446c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '../files/incorrect.txt'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[10], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m incorrectfile \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m../files/incorrect.txt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mr\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;66;03m# This will raise a FileNotFoundError since the file does not exist.\u001b[39;00m\n",
+      "File \u001b[1;32mc:\\Users\\kanwal\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\IPython\\core\\interactiveshell.py:324\u001b[0m, in \u001b[0;36m_modified_open\u001b[1;34m(file, *args, **kwargs)\u001b[0m\n\u001b[0;32m    317\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m file \u001b[38;5;129;01min\u001b[39;00m {\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m}:\n\u001b[0;32m    318\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[0;32m    319\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIPython won\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mt let you open fd=\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfile\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m by default \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    320\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mas it is likely to crash IPython. If you know what you are doing, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    321\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124myou can use builtins\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m open.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    322\u001b[0m     )\n\u001b[1;32m--> 324\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m io_open(file, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+      "\u001b[1;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '../files/incorrect.txt'"
+     ]
+    }
+   ],
+   "source": [
+    "incorrectfile = open(\"../files/incorrect.txt\", \"r\")\n",
+    "# This will raise a FileNotFoundError since the file does not exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "97d783ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'w:\\\\Repo\\\\python\\\\notebooks'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pwd # Print the current working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "542306e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The quick brown fox jumps over the lazy dog.\\nMachine learning algorithms process large datasets efficiently.\\nCloud computing enables scalable infrastructure solutions.\\nPython is a versatile language for data science.\\nRecursive functions solve complex problems elegantly.\\nNatural language processing transforms text into insights.\\nVersion control systems track code changes systematically.'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "myfile.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "940f51be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "myfile.read()\n",
+    "# This will return an empty string since the file pointer is at the end of the file after the first read()."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "66397364",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The quick brown fox jumps over the lazy dog.\\nMachine learning algorithms process large datasets efficiently.\\nCloud computing enables scalable infrastructure solutions.\\nPython is a versatile language for data science.\\nRecursive functions solve complex problems elegantly.\\nNatural language processing transforms text into insights.\\nVersion control systems track code changes systematically.'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "myfile.seek(0) # Move the file pointer back to the beginning of the file.\n",
+    "myfile.read() # Read the file again, this time it will return the content since we moved the pointer back to the beginning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b0b25510",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['The quick brown fox jumps over the lazy dog.\\n',\n",
+       " 'Machine learning algorithms process large datasets efficiently.\\n',\n",
+       " 'Cloud computing enables scalable infrastructure solutions.\\n',\n",
+       " 'Python is a versatile language for data science.\\n',\n",
+       " 'Recursive functions solve complex problems elegantly.\\n',\n",
+       " 'Natural language processing transforms text into insights.\\n',\n",
+       " 'Version control systems track code changes systematically.']"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "myfile.seek(0)\n",
+    "myfile.readlines() # Read the file again, this time it will return a list of lines in the file since we used readlines() instead of read()."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
This PR merges the `uno` branch into `main` and expands the repo’s beginner Python learning material. It adds new notebooks for booleans and file I/O, introduces sample files used by those exercises, and keeps the earlier notebook reorganization and intro examples that are part of this branch history.

## What Changed
- Added a boolean fundamentals notebook covering `True`/`False`, comparisons, and practical boolean usage in Python
- Added a file I/O notebook demonstrating:
  - reading files with `read()`, `readline()`, and `readlines()`
  - file pointer behavior
  - write and append flows with `w` and `a+`
  - file creation behavior with `x`
  - example error cases such as `FileNotFoundError` and `FileExistsError`
- Added sample files under `files/` to support the file handling exercises:
  - `temp.txt`
  - `test.txt`
  - `temp_new.txt`
  - `.gitkeep`
- Included the earlier branch work that is also being merged:
  - moved notebooks into the `notebooks/` directory
  - added `example.py` and `notebooks/example.ipynb`
  - added `notebooks/python-sets.ipynb` with a set exercise based on `"Mississippi"`

## Testing
- Not run
- Changes are limited to notebooks, sample text files, and a simple example script